### PR TITLE
Correctly include resources directory in build package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,0 @@
-include LICENSE
-include README.rst
-include resources/*
-
-recursive-exclude * __pycache__
-recursive-exclude * *.py[co]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "License :: OSI Approved :: MIT License"
 ]
+include = ["resources/**/*"]
 
 [tool.poetry.dependencies]
 python = "^3.6"


### PR DESCRIPTION
Fixes https://github.com/Textualize/textual/issues/2915

The `resources/` directory wasn't being included in the build.

Poetry doesn't make use of the `MANIFEST.in` file. It uses [this](https://python-poetry.org/docs/pyproject/#include-and-exclude) instead.