### PR TITLE
Prevent workers terminal summary for syrypy.

### DIFF
--- a/pytest_textual_snapshot.py
+++ b/pytest_textual_snapshot.py
@@ -290,6 +290,11 @@ def pytest_sessionfinish(
         diffs, num_snapshots_passing = retrieve_svg_diffs(tempdir)
         save_svg_diffs(diffs, session, num_snapshots_passing)
         tempdir.cleanup()
+    else:
+        config = session.config
+        plugin_manager = config.pluginmanager
+        syrupy = plugin_manager.getplugin('syrupy')
+        plugin_manager.unregister(syrupy)
 
 
 def retrieve_svg_diffs(


### PR DESCRIPTION
Unregister syrupy in pytest_session_finish for xdist workers so that syrupy does not run its pytest_terminal_summary hook.

For reasons unknown, when running the textual tests, the pytest_terminal_summary hook function consumes around 100% of a CPU core until the test run gets shut down. More annoyingly (to me) this causes a **~5 second pause** at the end of a test run.

This change causes workers to exit promptly.