### PR TITLE
point to the right homepage in the package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Darren Burns <darren@textualize.io>"]
 maintainers = ["Will McGugan <will@textualize.io>"]
 license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/darrenburns/pytest-textual-snapshot"
+homepage = "https://github.com/Textualize/pytest-textual-snapshot"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: Pytest",


### PR DESCRIPTION
This will, among other things, make it so that pypi points to the right place as well.

Noticed this when looking for a snapshotting solution for textual 